### PR TITLE
Change analyzer doc

### DIFF
--- a/pkg/bidichk/bidichk.go
+++ b/pkg/bidichk/bidichk.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	doc           = "bidichk detects dangerous unicode character sequences"
+	doc           = "Checks for dangerous unicode character sequences"
 	disallowedDoc = `comma separated list of disallowed runes (full name or short name)
 
 Supported runes


### PR DESCRIPTION
This PR changes the analyzer description to remove duplicated `bidichk` word:

Before:
```sh
❯ go run cmd/bidichk/main.go
bidichk: bidichk detects dangerous unicode character sequences
```
After:
```sh
❯ go run cmd/bidichk/main.go
bidichk: Checks for dangerous unicode character sequences
```

Also, after this PR is merged we can refactor the [golangci-lint code](https://github.com/golangci/golangci-lint/blob/ce020c6be1b8f9da457436fa9b85f7f54f8107b7/pkg/golinters/bidichk.go#L53C1-L59C1) to the following:

```go
	return goanalysis.NewLinter(
		a.Name,
		a.Doc,
		[]*analysis.Analyzer{a},
		cfgMap,
	).WithLoadMode(goanalysis.LoadModeSyntax)

```

